### PR TITLE
Refactor swerve constants into parameters package

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -13,6 +13,9 @@ package frc.robot;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+  public static class RobotConstants {
+    public static final double kMaxBatteryVoltage = 12.0;
+  }
   public static class OperatorConstants {
     public static final int kDriverControllerPort = 0;
   }

--- a/src/main/java/frc/robot/commands/FollowTrajectory.java
+++ b/src/main/java/frc/robot/commands/FollowTrajectory.java
@@ -46,8 +46,8 @@ public class FollowTrajectory extends SwerveControllerCommand {
       List<Translation2d> waypoints,
       Pose2d end,
       TrajectoryConstraint... constraints) {
-    TrajectoryConfig config = new TrajectoryConfig(SwerveModule.kMaxDriveSpeed, SwerveModule.kMaxDriveAcceleration)
-        .addConstraint(new SwerveDriveKinematicsConstraint(SwerveSubsystem.kKinematics, SwerveModule.kMaxDriveSpeed))
+    TrajectoryConfig config = new TrajectoryConfig(drivetrain.getMaxSpeed(), drivetrain.getMaxAcceleration())
+        .addConstraint(drivetrain.getKinematicsConstraint())
         .addConstraints(List.of(constraints));
     Trajectory trajectory = TrajectoryGenerator.generateTrajectory(start, waypoints, end, config);
 
@@ -74,9 +74,11 @@ public class FollowTrajectory extends SwerveControllerCommand {
    * 
    * @return A new ProfiledPIDController for steering control.
    */
-  private static ProfiledPIDController createProfiledPIDController() {
-    ProfiledPIDController ppc = new ProfiledPIDController(1.0, 0.0, 0.0, SwerveModule.kSteeringConstraints);
+  private static ProfiledPIDController createProfiledPIDController(SwerveSubsystem drivetrain) {
+    ProfiledPIDController ppc = new ProfiledPIDController(1.0, 0.0, 0.0, drivetrain.getSteeringConstraints());
+
     ppc.enableContinuousInput(-Math.PI, Math.PI);
+
     return ppc;
   }
 
@@ -94,7 +96,7 @@ public class FollowTrajectory extends SwerveControllerCommand {
         new HolonomicDriveController(
             new PIDController(1.0, 0.0, 0.0),
             new PIDController(1.0, 0.0, 0.0),
-            FollowTrajectory.createProfiledPIDController()),
+            FollowTrajectory.createProfiledPIDController(drivetrain)),
         drivetrain::setModuleStates);
     this.drivetrain = drivetrain;
   }

--- a/src/main/java/frc/robot/drive/SwerveDrive.java
+++ b/src/main/java/frc/robot/drive/SwerveDrive.java
@@ -14,19 +14,22 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.drive.RobotDriveBase;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-
+import frc.robot.parameters.SwerveDriveParameters;
 
 /** SwerveDrive implements swerve drive control. */
 public class SwerveDrive extends RobotDriveBase {
-   
     private final SwerveModule[] modules;
     private final SwerveDriveKinematics kinematics;
     private final DoubleSupplier fieldOrientation;
-    private final double maxRotationalVelocity;
+    private final double maxDriveSpeed;
+    private final double maxRotationalSpeed;
 
     /**
      * constructs the swerve drive
      * 
+     * @param parameters       A {@link SwerveDriveParameters} object providing
+     *                         information on the physical swerve drive
+     *                         characteristics.
      * @param modules          An array of four {@link SwerveModule} objects in the
      *                         order: front left, front right, back left, back
      *                         right.
@@ -35,11 +38,15 @@ public class SwerveDrive extends RobotDriveBase {
      *                         states.
      * @param fieldOrientation Supplies the robot orientation relative to the field.
      */
-    public SwerveDrive(SwerveModule[] modules, SwerveDriveKinematics kinematics, DoubleSupplier fieldOrientation, double maxRotationalVelocity) {
+    public SwerveDrive(
+            SwerveDriveParameters parameters,
+            SwerveModule[] modules,
+            DoubleSupplier fieldOrientation) {
         this.modules = modules;
-        this.kinematics = kinematics;
+        this.kinematics = parameters.getKinematics();
         this.fieldOrientation = fieldOrientation;
-        this.maxRotationalVelocity = maxRotationalVelocity;
+        this.maxDriveSpeed = parameters.getMaxDriveSpeed();
+        this.maxRotationalSpeed = parameters.getMaxRobotRotationalSpeed();
     }
 
     /**
@@ -49,8 +56,8 @@ public class SwerveDrive extends RobotDriveBase {
      *               order: front left, front right, back left, back right
      */
     public void setModuleStates(SwerveModuleState[] states) {
-        SwerveDriveKinematics.desaturateWheelSpeeds(states, SwerveModule.kMaxDriveSpeed);
-        
+        SwerveDriveKinematics.desaturateWheelSpeeds(states, maxDriveSpeed);
+
         for (int i = 0; i < modules.length; ++i) {
             modules[i].setModuleState(states[i]);
         }
@@ -83,9 +90,9 @@ public class SwerveDrive extends RobotDriveBase {
     public void drive(double xSpeed, double ySpeed, double rSpeed, boolean fieldRelative, boolean squareInputs) {
         // Applies deadbands to x, y, and rotation joystick values and multiples all
         // values with max speed.
-        xSpeed = MathUtil.applyDeadband(xSpeed, m_deadband) * SwerveModule.kMaxDriveSpeed;
-        ySpeed = MathUtil.applyDeadband(ySpeed, m_deadband) * SwerveModule.kMaxDriveSpeed;
-        rSpeed = MathUtil.applyDeadband(rSpeed, m_deadband) * maxRotationalVelocity;
+        xSpeed = MathUtil.applyDeadband(xSpeed, m_deadband) * m_maxOutput * maxDriveSpeed;
+        ySpeed = MathUtil.applyDeadband(ySpeed, m_deadband) * m_maxOutput * maxDriveSpeed;
+        rSpeed = MathUtil.applyDeadband(rSpeed, m_deadband) * m_maxOutput * maxRotationalSpeed;
 
         if (squareInputs) {
             xSpeed *= xSpeed;
@@ -109,8 +116,8 @@ public class SwerveDrive extends RobotDriveBase {
      */
     public SwerveModulePosition[] getModulesPositions() {
         SwerveModulePosition[] modulePosition = new SwerveModulePosition[4];
-        for(int i = 0; i < modules.length; i++) {
-            modulePosition[i] = modules[i].getPosition(); 
+        for (int i = 0; i < modules.length; i++) {
+            modulePosition[i] = modules[i].getPosition();
         }
         return modulePosition;
     }

--- a/src/main/java/frc/robot/parameters/MotorParameters.java
+++ b/src/main/java/frc/robot/parameters/MotorParameters.java
@@ -1,0 +1,69 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.parameters;
+
+/** A enum representing the properties on a specific motor type. */
+public enum MotorParameters {
+  /**
+   * A VEX PRO <a href="https://www.vexrobotics.com/217-6515.html">Falcon 500</a>
+   * motor with integrated Talon FX motor controller and encoders.
+   */
+  Falcon500(6380.0, 4.69, 2048),
+
+  /**
+   * A REV Robotics <a href="https://www.revrobotics.com/rev-21-1650/">
+   * NEO Brushless Motor V1.1</a> with integrated encoder.
+   */
+  NeoV1_1(5676.0, 3.75, 42),
+
+  /**
+   * A REV Robotics <a href="https://www.revrobotics.com/rev-21-1651/">
+   * NEO 550 Brushless Motor</a> with integrated encoder.
+   */
+  Neo550(11000.0, 0.97, 42);
+
+  private double freeSpeedRPM;
+  private double stallTorque;
+  private int pulsesPerRevolution;
+
+  /**
+   * Constructs an instance of this class.,
+   * 
+   * @param freeSpeedRPM The free speed RPM.
+   * @param stallTorque  The stall torque in Nm.
+   */
+  MotorParameters(double freeSpeedRPM, double stallTorque, int pulsesPerRevolution) {
+    this.freeSpeedRPM = freeSpeedRPM;
+    this.stallTorque = stallTorque;
+    this.pulsesPerRevolution = pulsesPerRevolution;
+  }
+
+  /**
+   * Returns the free speed RPM of the motor.
+   * 
+   * @return The free speed RPM.
+   */
+  public double getFreeSpeedRPM() {
+    return this.freeSpeedRPM;
+  }
+
+  /**
+   * Returns the stall torque of the motor in Nm.
+   * 
+   * @return The stall torque in Nm.
+   */
+  public double getStallTorque() {
+    return this.stallTorque;
+  }
+
+  /**
+   * Returns the number of pulses per revolution of the integrated encoder.
+   * 
+   * @return The number of pulses per revolution of the integrated encoder.
+   */
+  public int getPulsesPerRevolution() {
+    return this.pulsesPerRevolution;
+  }
+}

--- a/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveDriveParameters.java
@@ -1,0 +1,358 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.parameters;
+
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.math.trajectory.constraint.SwerveDriveKinematicsConstraint;
+import edu.wpi.first.math.util.Units;
+import static frc.robot.Constants.*;
+import static frc.robot.parameters.MotorParameters.Falcon500;
+import static frc.robot.parameters.SwerveModuleParameters.MK4Standard;
+
+/**
+ * An enum representing the properties for the swerve drive base of a specific
+ * robot instance.
+ */
+public enum SwerveDriveParameters {
+
+  /** The 2022 competition robot. */
+  Competition2022(
+      67.5853,
+      Units.inchesToMeters(26.3),
+      Units.inchesToMeters(19.5),
+      MK4Standard,
+      Falcon500,
+      1.0,
+      1.0);
+
+  /**
+   * A scaling factor used to adjust from theoretical maximums given that any
+   * physical system generally cannot achieve them.
+   */
+  private static final double SCALE_FACTOR = 0.80;
+
+  private final double robotMass;
+  private final double wheelDistanceX;
+  private final double wheelDistanceY;
+  private final SwerveModuleParameters swerveModule;
+  private final MotorParameters motor;
+
+  private double maxDriveSpeed;
+  private double maxDriveAcceleration;
+
+  private final double driveKs;
+  private final double driveKv;
+  private final double driveKa;
+
+  private double maxSteeringSpeed;
+  private double maxSteeringAcceleration;
+
+  private final double steeringKs;
+  private final double steeringKv;
+  private final double steeringKa;
+
+  private double maxRobotRotationalSpeed;
+
+  private final Translation2d[] wheelPositions;
+  private final SwerveDriveKinematics kinematics;
+  private final SwerveDriveKinematicsConstraint kinematicsConstraint;
+  private final TrapezoidProfile.Constraints steeringConstraints;
+
+  /**
+   * Constructs an instance of this enum.
+   * <p>
+   * <b>NOTE:</b> The distance between wheels are expressed in the NWU coordinate
+   * system relative to the robot frame as shown below.
+   * <p>
+   * 
+   * <pre>
+   * <code>
+   *            ^
+   * +--------+ | x
+   * |O      O| |
+   * |        | |
+   * |        | |
+   * |O      O| |
+   * +--------+ |
+   *            |
+   * <----------+
+   *  y       (0,0)
+   * </code>
+   * </pre>
+   * 
+   * @param robotMass      The mass of the robot in Kg.
+   * @param wheelDistanceX The distance between the wheels along the X axis in
+   *                       meters.
+   * @param wheelDistanceY The distance between the wheels along the Y axis in
+   *                       meters
+   * @param swerveModule   The swerve module used by the robot.
+   * @param motor          The motor used by swerve module on the robot.
+   */
+  private SwerveDriveParameters(
+      double robotMass,
+      double wheelDistanceX,
+      double wheelDistanceY,
+      SwerveModuleParameters swerveModule,
+      MotorParameters motor,
+      double driveKs,
+      double steeringKs) {
+    this.robotMass = robotMass;
+    this.wheelDistanceX = wheelDistanceX;
+    this.wheelDistanceY = wheelDistanceY;
+    this.swerveModule = swerveModule;
+    this.motor = motor;
+
+    this.maxDriveSpeed = SCALE_FACTOR * this.swerveModule.calculateMaxDriveSpeed(this.motor);
+    this.maxDriveAcceleration = SCALE_FACTOR
+        * this.swerveModule.calculateMaxDriveAcceleration(this.motor, this.robotMass);
+
+    this.driveKs = driveKs;
+    this.driveKv = (RobotConstants.kMaxBatteryVoltage - this.driveKs) / this.maxDriveSpeed;
+    this.driveKa = (RobotConstants.kMaxBatteryVoltage - this.driveKs) / this.maxDriveAcceleration;
+
+    this.maxSteeringSpeed = SCALE_FACTOR * this.swerveModule.calculateMaxSteeringSpeed(this.motor);
+    this.maxSteeringAcceleration = SCALE_FACTOR
+        * this.swerveModule.calculateMaxSteeringAcceleration(this.motor, this.robotMass);
+
+    this.steeringKs = steeringKs;
+    this.steeringKv = (RobotConstants.kMaxBatteryVoltage - this.steeringKs) / this.maxSteeringSpeed;
+    this.steeringKa = (RobotConstants.kMaxBatteryVoltage - this.steeringKs) / maxSteeringAcceleration;
+
+    this.maxRobotRotationalSpeed = this.maxDriveSpeed / Math.hypot(this.wheelDistanceX, this.wheelDistanceY);
+
+    this.wheelPositions = new Translation2d[] {
+        new Translation2d(this.wheelDistanceX / 2.0, this.wheelDistanceY / 2),
+        new Translation2d(this.wheelDistanceX / 2.0, -this.wheelDistanceY / 2),
+        new Translation2d(-this.wheelDistanceX / 2.0, this.wheelDistanceY / 2),
+        new Translation2d(-this.wheelDistanceX / 2.0, -this.wheelDistanceY / 2),
+    };
+
+    this.kinematics = new SwerveDriveKinematics(wheelPositions);
+    this.kinematicsConstraint = new SwerveDriveKinematicsConstraint(kinematics, this.maxDriveSpeed);
+    this.steeringConstraints = new TrapezoidProfile.Constraints(this.maxSteeringSpeed, this.maxSteeringAcceleration);
+  }
+
+  /**
+   * Returns the mass of the robot in Kg.
+   * 
+   * @return The mass of the robot in Kg.
+   */
+  public double getRobotMass() {
+    return this.robotMass;
+  }
+
+  /**
+   * Returns the maximum rotational speed of the robot in rad/s.
+   * 
+   * @return The maximum rotation speed of the robot in rad/s.
+   */
+  public double getMaxRobotRotationalSpeed() {
+    return this.maxRobotRotationalSpeed;
+  }
+
+  /**
+   * Returns the distance between the wheels along the X-axis in meters.
+   * 
+   * @return The distance between the wheels along the X-axis in meters.
+   */
+  public double getWheelDistanceX() {
+    return this.wheelDistanceX;
+  }
+
+  /**
+   * Returns the distance between the wheels along the Y-axis in meters.
+   * 
+   * @return The distance between the wheels along the Y-axis in meters.
+   */
+  public double getWheelDistanceY() {
+    return this.wheelDistanceY;
+  }
+
+  /**
+   * Returns the wheel positions relative to the robot center.
+   * 
+   * @return The wheel positions relative to the robot center.
+   */
+  public Translation2d[] getWheelPositions() {
+    return this.wheelPositions;
+  }
+
+  /**
+   * Returns the swerve module used by the robot.
+   * 
+   * @return The swerve module used by the robot.
+   */
+  public SwerveModuleParameters getSwerveModule() {
+    return this.swerveModule;
+  }
+
+  /**
+   * Returns the motor used by swerve module on the robot.
+   * 
+   * @return The motor used by swerve module on the robot.
+   */
+  public MotorParameters getMotorParameters() {
+    return this.motor;
+  }
+
+  /**
+   * Returns the maximum drive speed in m/s of a swerve module.
+   * 
+   * @return The maximum drive speed.
+   */
+  public double getMaxDriveSpeed() {
+    return this.maxDriveSpeed;
+  }
+
+  /**
+   * Returns the maximum drive acceleration in m/s^2 of a swerve module.
+   * 
+   * @return The maximum drive acceleration.
+   */
+  public double getMaxDriveAcceleration() {
+    return this.maxDriveAcceleration;
+  }
+
+  /**
+   * Returns the kS feedforward control constant for translation in Volts.
+   * <p>
+   * This is the voltage needed to overcome the internal friction of the motor.
+   * 
+   * @return The kS feedforward control constant for translation in Volts.
+   */
+  public double getDriveKs() {
+    return this.driveKs;
+  }
+
+  /**
+   * Returns the kV feedforward control constant for translation in Volt * seconds
+   * per meter.
+   * <p>
+   * This is used to calculate the voltage needed to maintain a constant velocity.
+   * 
+   * @return The kV feedforward control constant for translation in Volt * seconds
+   *         per meter.
+   */
+  public double getDriveKv() {
+    return this.driveKv;
+  }
+
+  /**
+   * Returns the kA feedforward control constant for translation in Volt *
+   * seconds^2 per meter.
+   * <p>
+   * This is used to calculate the voltage needed to maintain a constant
+   * acceleration.
+   * 
+   * @return The kA feedforward control constant for translation in Volt *
+   *         seconds^2 per meter.
+   */
+  public double getDriveKa() {
+    return this.driveKa;
+  }
+
+  /**
+   * Returns the pulses per meter of the integrated encoder.
+   * 
+   * @return The pulses per meter of the integrated encoder.
+   */
+  public double getDrivePulsesPerMeter() {
+    return this.swerveModule.calculateDrivePulsesPerMeter(this.motor);
+  }
+
+  /**
+   * Returns a {@link SwerveDriveKinematics} object used to convert chassis speeds
+   * to individual module states.
+   * 
+   * @return A {@link SwerveDriveKinematics} object used to convert chassis speeds
+   *         to individual module states.
+   */
+  public SwerveDriveKinematics getKinematics() {
+    return this.kinematics;
+  }
+
+  /**
+   * Returns a {@link SwerveDriveKinematicsConstraint} object used to enforce
+   * swerve drive kinematics constraints when following a trajectory.
+   * 
+   * @return A {@link SwerveDriveKinematicsConstraint} object used to enforce
+   *         swerve drive kinematics constraints when following a trajectory.
+   */
+  public SwerveDriveKinematicsConstraint getKinematicsConstraint() {
+    return this.kinematicsConstraint;
+  }
+
+  /**
+   * Returns the maximum steering speed in rad/s of a swerve module.
+   * 
+   * @return The maximum steering speed.
+   */
+  public double getMaxSteeringSpeed() {
+    return this.maxSteeringSpeed;
+  }
+
+  /**
+   * Returns the maximum steering acceleration in rad/s^2 of a swerve module.
+   * 
+   * @return The maximum steering acceleration.
+   */
+  public double getMaxSteeringAcceleration() {
+    return this.maxSteeringAcceleration;
+  }
+
+  /**
+   * Returns the kS feedforward control constant for rotation in Volts.
+   * <p>
+   * This is the voltage needed to overcome the internal friction of the motor.
+   * 
+   * @return The kS feedforward control constant for rotation in Volts.
+   */
+  public double getSteeringKs() {
+    return this.steeringKs;
+  }
+
+  /**
+   * Returns the kV feedforward control constant for rotation in Volt * seconds
+   * per radian.
+   * <p>
+   * This is used to calculate the voltage needed to maintain a constant steering
+   * velocity.
+   * 
+   * @return The kV feedforward control constant for translation in Volt * seconds
+   *         per radian.
+   */
+  public double getSteeringKv() {
+    return this.steeringKv;
+  }
+
+  /**
+   * Returns the kA feedforward control constant for rotation in Volt *
+   * seconds^2 per radian.
+   * <p>
+   * This is used to calculate the voltage needed to maintain a constant
+   * rotational acceleration.
+   * 
+   * @return The kA feedforward control constant for translation in Volt *
+   *         seconds^2 per radian.
+   */
+  public double getSteeringKa() {
+    return this.steeringKa;
+  }
+
+  /**
+   * Returns a {@link TrapezoidProfile.Constraints} object used to enforce
+   * velocity and acceleration constraints on the {@link ProfiledPIDController}
+   * used to reach the goal wheel angle.
+   * 
+   * @return A {@link TrapezoidProfile.Constraints} object used to enforce
+   *         velocity and acceleration constraints on the controller used to reach
+   *         the goal wheel angle.
+   */
+  public TrapezoidProfile.Constraints getSteeringConstraints() {
+    return steeringConstraints;
+  }
+}

--- a/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
@@ -1,0 +1,137 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.parameters;
+
+import edu.wpi.first.math.util.Units;
+
+/**
+ * A enum representing the properties on a specific swerve drive module.
+ * <p>
+ * The parameters for the MK4 modules are taken from <a
+ * href="https://www.swervedrivespecialties.com/products/mk4-swerve-module">
+ * MK4 Swerve Module</a>.
+ * <p>
+ * The calculations for the theoretical maximum speeds and acceleration are
+ * taken from the <a href=
+ * "https://www.chiefdelphi.com/uploads/default/original/3X/f/7/f79d24101e6f1487e76099774e4ba60683e86cda.pdf">
+ * FRC Drivetrain Characterization</a> paper by Noah Gleason and Eli Barnett of
+ * FRC Team 449 - The Blair Robot Project.
+ */
+public enum SwerveModuleParameters {
+  /** An MK4 Swerve Module in the L1 - Standard configuration. */
+  MK4Standard(Units.inchesToMeters(4.0), 8.14, 12.8),
+
+  /** An MK4 Swerve Module in the L2 - Fast configuration. */
+  MK4Fast(Units.inchesToMeters(4.0), 6.75, 12.8),
+
+  /** An MK4 Swerve Module in the L3 - Very Fast configuration. */
+  MK4VeryFast(Units.inchesToMeters(4.0), 6.12, 12.8),
+  
+  /** An MK4 Swerve Module in the L4 - Too Fast configuration. */
+  MK4TooFast(Units.inchesToMeters(4.0), 5.14, 12.8);
+
+  private final double wheelDiameter;
+  private final double driveGearRatio;
+  private final double steeringGearRatio;
+
+  /**
+   * Constructs an instance of this enum.
+   * 
+   * @param wheelDiameter     The wheel diameter in meters.
+   * @param driveGearRatio    The drive gear ratio.
+   * @param steeringGearRatio The steering gear ratio.
+   */
+  SwerveModuleParameters(double wheelDiameter, double driveGearRatio, double steeringGearRatio) {
+    this.wheelDiameter = wheelDiameter;
+    this.driveGearRatio = driveGearRatio;
+    this.steeringGearRatio = steeringGearRatio;
+  }
+
+  /**
+   * Returns the wheel radius in meters.
+   * 
+   * @return The wheel radius in meters.
+   */
+  public double getWheelDiameter() {
+    return this.wheelDiameter;
+  }
+
+  /**
+   * Returns the drive gear ratio.
+   * 
+   * @return The drive gear ratio.
+   */
+  public double getDriveGearRation() {
+    return this.driveGearRatio;
+  }
+
+  /**
+   * Returns the steering gear ratio.
+   * 
+   * @return The steering gear ratio.
+   */
+  public double getSteeringGearRatio() {
+    return this.steeringGearRatio;
+  }
+
+  /**
+   * Returns the pulses per meter of the integrated encoder on the specified
+   * motor.
+   * 
+   * @param motor
+   * @return The pulses per meter of the integrated encoder on the specified
+   *         motor.
+   */
+  public double calculateDrivePulsesPerMeter(MotorParameters motor) {
+    return (motor.getPulsesPerRevolution() * this.driveGearRatio) / (this.wheelDiameter * Math.PI);
+  }
+
+  /**
+   * Returns the theoretical maximum drive speed in m/s when using the specified
+   * motor.
+   * 
+   * @param motor The motor parameters.
+   * @return The theoretical maximum drive speed.
+   */
+  public double calculateMaxDriveSpeed(MotorParameters motor) {
+    return (motor.getFreeSpeedRPM() * this.wheelDiameter * Math.PI) / (60.0 * this.driveGearRatio);
+  }
+
+  /**
+   * Returns the theoretical maximum drive acceleration in m/s^2 when using the
+   * specified motor.
+   * 
+   * @param motor     The motor parameters.
+   * @param robotMass the total robot mass in Kg including bumpers and battery.
+   * @return The theoretical maximum drive acceleration.
+   */
+  public double calculateMaxDriveAcceleration(MotorParameters motor, double robotMass) {
+    return (2 * 4 * motor.getStallTorque()) / (this.wheelDiameter * robotMass);
+  }
+
+  /**
+   * Returns the theoretical maximum steering speed in rad/s when using the
+   * specified motor.
+   * 
+   * @param motor The motor parameters.
+   * @return The theoretical maximum drive speed.
+   */
+  public double calculateMaxSteeringSpeed(MotorParameters motor) {
+    return (motor.getFreeSpeedRPM() * 2 * Math.PI) / (60.0 * this.steeringGearRatio);
+  }
+
+  /**
+   * Returns the theoretical maximum drive acceleration in rad/s^2 when using the
+   * specified motor.
+   * 
+   * @param motor     The motor parameters.
+   * @param robotMass the total robot mass in Kg including bumpers and battery.
+   * @return The theoretical maximum drive acceleration.
+   */
+  public double calculateMaxSteeringAcceleration(MotorParameters motor, double robotMass) {
+    // TODO: Determine correct calculation.
+    return 4 * Math.PI;
+  }
+}

--- a/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
+++ b/src/main/java/frc/robot/parameters/SwerveModuleParameters.java
@@ -28,7 +28,7 @@ public enum SwerveModuleParameters {
 
   /** An MK4 Swerve Module in the L3 - Very Fast configuration. */
   MK4VeryFast(Units.inchesToMeters(4.0), 6.12, 12.8),
-  
+
   /** An MK4 Swerve Module in the L4 - Too Fast configuration. */
   MK4TooFast(Units.inchesToMeters(4.0), 5.14, 12.8);
 
@@ -108,7 +108,7 @@ public enum SwerveModuleParameters {
    * @return The theoretical maximum drive acceleration.
    */
   public double calculateMaxDriveAcceleration(MotorParameters motor, double robotMass) {
-    return (2 * 4 * motor.getStallTorque()) / (this.wheelDiameter * robotMass);
+    return (2 * 4 * motor.getStallTorque() * this.driveGearRatio) / (this.wheelDiameter * robotMass);
   }
 
   /**
@@ -131,7 +131,6 @@ public enum SwerveModuleParameters {
    * @return The theoretical maximum drive acceleration.
    */
   public double calculateMaxSteeringAcceleration(MotorParameters motor, double robotMass) {
-    // TODO: Determine correct calculation.
-    return 4 * Math.PI;
+    return (2 * 4 * motor.getStallTorque() * this.steeringGearRatio * 2 * Math.PI) / robotMass;
   }
 }


### PR DESCRIPTION
Refactors the swerve drive constants into a set of enums with accessors. The `MotorParameters` and `SwerveModuleParameters` enums define parameters for the motors and physical swerve modules, respectively, The `SwerveDriveParameters` enum combines these two along with the physical properties of the robot to determine the appropriate values needed for swerve drive control.

As the new practice and competition bases become available, we can add additional values to the `SwerveDriveParameters` enum for each. Using nrgcommon lib's [RobotPreferences.EnumValue<T>](https://github.com/NRG948/nrgcommon/blob/5f5b35bbb2aa20d6dd20bcc5d496ce6f866d8658/nrgcommon/src/main/java/com/nrg948/preferences/RobotPreferences.java#L323) to allow easy selection among the options. Since the preferences are stored on the Roborio, switching among the different bases for testing becomes automatic.